### PR TITLE
Adjusted the touchend listener and added the clearPebble(id) function…

### DIFF
--- a/game.js
+++ b/game.js
@@ -74,7 +74,11 @@ function renderTree(depth) {
       el.addEventListener('mouseup', (e) => {
         clearTimeout(holdTimeout);
         if (!holdTriggered) {
-          if (isLeaf) {
+          if (node.hasPebble)
+          {
+            clearPebble(node.id);
+          }
+          else if (isLeaf) {
             togglePebble(node.id);
           }
         }
@@ -160,6 +164,20 @@ function togglePebble(id) {
   if (node.hasPebble) pebbleBank--;
   else pebbleBank++;
 
+  updatePebbleBank();
+  renderTree(treeDepth);
+}
+
+function clearPebble(id) {
+  const node = nodes[id];
+  if(node.hasPebble) 
+  {
+    const prev = { id, wasPebbled: node.hasPebble, type: "toggle" };
+    undoStack.push(prev);
+
+    node.hasPebble = false;
+    pebbleBank++;
+  }
   updatePebbleBank();
   renderTree(treeDepth);
 }


### PR DESCRIPTION
… to allow for non-leaf nodes to be cleared with a single click.

This pull request should update the site to allow non-leaf nodes to have their pebble removed and returned to the pebble bank with a single click, just as leaf nodes may have their pebbles removed.

I believe this PR will resolve Issue #2.